### PR TITLE
Allow 'expand' in search requests

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -878,7 +878,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 jql: searchString,
                 startAt: optional.startAt || 0,
                 maxResults: optional.maxResults || 50,
-                fields: optional.fields || ["summary", "status", "assignee", "description"]
+                fields: optional.fields || ["summary", "status", "assignee", "description"],
+                expand: optional.expand
             }
         };
 


### PR DESCRIPTION
Thanks for publishing on NPM -- the original project hasn't been updated in quite a while....

This is a crazy-small change to allow a caller of `searchJira` to specify expand properties to be returned with the results.  My usage is that I need to get the changelog for issues in order to interpret the actual resolution date, which I expect is common amongst API users.